### PR TITLE
Make info/debug log statements conditional.

### DIFF
--- a/snippets/slim.code-snippets
+++ b/snippets/slim.code-snippets
@@ -19,7 +19,7 @@
 		"scope": "perl",
 		"prefix": "slimlogdebug",
 		"body": [
-			"\\$log->debug(\"$1\");"
+			"main::DEBUGLOG && \\$log->is_debug && \\$log->debug(\"$1\");"
 		],
 		"description": "Slim Debug Log"
 	},
@@ -27,7 +27,7 @@
 		"scope": "perl",
 		"prefix": "slimloginfo",
 		"body": [
-			"\\$log->info(\"$1\");"
+			"main::INFOLOG && \\$log->is_info && \\$log->info(\"$1\");"
 		],
 		"description": "Slim Info Log"
 	},


### PR DESCRIPTION
The server can be run without support for INFO or DEBUG, which would load additional modules. Using them in that situation would crash LMS. Therefore you should always check whether INFOLOG or DEBUGLOG are enabled.